### PR TITLE
Restrict use of av1M in AV1 HDR10+ ISOBMFF files

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -199,7 +199,7 @@ The <a href="https://aomediacodec.github.io/av1-isobmff/#cmaf">CMAF AV1 track fo
 
 A CMAF AV1 track that conforms to this specification (i.e. contains HDR10+ metadata OBUs) should use the compatible brand code "cdm4" identified in [[!CTA-5001]] in the `ftyp` box, in addition to the CMAF file brand `av01`.
 
-
+AV1 Metadata sample group entry `av1M` shall not be used. 
 
 
 HDR10+ Compatible Manifests


### PR DESCRIPTION
close #16.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/podborski/av1-hdr10plus/pull/17.html" title="Last updated on Nov 8, 2021, 6:44 PM UTC (5501b64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-hdr10plus/17/fbefb1f...podborski:5501b64.html" title="Last updated on Nov 8, 2021, 6:44 PM UTC (5501b64)">Diff</a>