### PR TITLE
Highlight the anchor element

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -295,3 +295,15 @@ Example Streams and Tools {#tools}
 ==========================
 
 Information on this topic is found in the <a href="https://github.com/AOMediaCodec/av1-hdr10plus/wiki">Wiki</a> for this project.
+
+<script>
+if (window.location.hash) {
+  const highlight_span = document.querySelector(window.location.hash);
+  if (highlight_span) {
+    highlight_span.parentNode.style.backgroundColor = "#F4EA565A";
+    setTimeout(() => {
+      highlight_span.parentNode.style.backgroundColor = "";
+    }, 5000);
+  }
+}
+</script>


### PR DESCRIPTION
This would be useful for highlighting the assert ids when linked from the conformance page. The color can be changed but it looks okay right now.

<img width="853" alt="Screenshot 2023-06-01 at 10 31 47" src="https://github.com/AOMediaCodec/av1-hdr10plus/assets/7467169/23b1e3bc-2aee-4c9f-a6d2-ec7f373256e9">


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-hdr10plus/pull/60.html" title="Last updated on Jun 1, 2023, 5:32 PM UTC (4c416d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-hdr10plus/60/0c64dd0...4c416d1.html" title="Last updated on Jun 1, 2023, 5:32 PM UTC (4c416d1)">Diff</a>