### PR TITLE
On redundant sentences regarding show_frame=0 and other conformance related issues

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ As defined in [[!AV1]], an [=AV1 coded video sequence=] consists of one or more 
 
 Consequently, <assert>for each frame with <code>[=show_frame=] = 1</code> or <code>[=show_existing_frame=] = 1</code>, there shall be one and only one [=HDR10+ metadata OBU=] preceding the [=Frame Header OBU=] for this frame and located after the last [=OBU=] of the previous frame (if any) or after the [=Sequence Header OBU=] (if any) or after the start of the [=temporal unit=]</assert> (e.g. after the [=Temporal Delimiter OBU=], for storage formats where [=Temporal Delimiter OBUs=] are preserved).
 
-<assert>[=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code></assert>. <assert>For non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]</assert>. For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
+[=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code>. For non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]. For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
 
 Figure 2 shows a simplified example of placement of [=HDR10+ Metadata OBUs=] in an AV1 bitstream.
 

--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,9 @@ As defined in [[!AV1]], an [=AV1 coded video sequence=] consists of one or more 
 
 Consequently, <assert>for each frame with <code>[=show_frame=] = 1</code> or <code>[=show_existing_frame=] = 1</code>, there shall be one and only one [=HDR10+ metadata OBU=] preceding the [=Frame Header OBU=] for this frame and located after the last [=OBU=] of the previous frame (if any) or after the [=Sequence Header OBU=] (if any) or after the start of the [=temporal unit=]</assert> (e.g. after the [=Temporal Delimiter OBU=], for storage formats where [=Temporal Delimiter OBUs=] are preserved).
 
-NOTE: As a consequence of the above statements the [=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code>. For non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]. For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
+NOTE: As a consequence of the above statements [=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code>. Additionally, for non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]. 
+
+For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
 
 Figure 2 shows a simplified example of placement of [=HDR10+ Metadata OBUs=] in an AV1 bitstream.
 

--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ As defined in [[!AV1]], an [=AV1 coded video sequence=] consists of one or more 
 
 Consequently, <assert>for each frame with <code>[=show_frame=] = 1</code> or <code>[=show_existing_frame=] = 1</code>, there shall be one and only one [=HDR10+ metadata OBU=] preceding the [=Frame Header OBU=] for this frame and located after the last [=OBU=] of the previous frame (if any) or after the [=Sequence Header OBU=] (if any) or after the start of the [=temporal unit=]</assert> (e.g. after the [=Temporal Delimiter OBU=], for storage formats where [=Temporal Delimiter OBUs=] are preserved).
 
-[=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code>. For non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]. For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
+NOTE: As a consequence of the above statements the [=HDR10+ Metadata OBUs=] are not provided when <code>[=show_frame=] = 0</code>. For non-layered streams, there is only one [=HDR10+ Metadata OBU=] per [=temporal unit=]. For [[!AV1]] bitstreams encoded with multiple layers, [=HDR10+ Metadata=] may apply to one or more layers. However, the details are out of scope of this version of the specification.
 
 Figure 2 shows a simplified example of placement of [=HDR10+ Metadata OBUs=] in an AV1 bitstream.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-hdr10plus/pull/64.html" title="Last updated on Sep 13, 2023, 5:23 PM UTC (9d17e2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/av1-hdr10plus/64/99b14c5...9d17e2a.html" title="Last updated on Sep 13, 2023, 5:23 PM UTC (9d17e2a)">Diff</a>